### PR TITLE
Added "Don't forget to save!" dialog after option import

### DIFF
--- a/options.html
+++ b/options.html
@@ -375,7 +375,7 @@
 				<p><strong>Error:</strong> Unable to import options from sync storage.</p>
 			</div>
 			<div id="alertImportSuccess" title="LeechBlock Options">
-				<p>The options have been imported successfully.</p>
+				<p>The options have been imported successfully. Don't forget to save!</p>
 			</div>
 			<div id="alertExportError" title="LeechBlock Options">
 				<p><strong>Error:</strong> Unable to download exported options.</p>


### PR DESCRIPTION
I've found that it is super easy to forget to press the "Save Options" button after importing options from either a file or sync storage. This pull request adds the text "Don't forget to save!" to the import confirmation dialog.