### PR TITLE
Add warning to users to make sure overriding is enabled

### DIFF
--- a/options.html
+++ b/options.html
@@ -153,7 +153,7 @@
 							</p>
 							<p>
 								<input id="allowOverride1" type="checkbox">
-								<label for="allowOverride1">Allow temporary override for these sites</label>
+								<label for="allowOverride1">Allow temporary override for these sites (must also be enabled in General settings)</label>
 							</p>
 						</fieldset>
 						<p>


### PR DESCRIPTION
For a long time I didn't understand why I couldn't override anything
even though "Allow temporary override for these sites" was checked in my
Block Set options. I was honestly about to file it as a bug before I
checked the code and realized there was another place entirely where
overriding has to be enabled.

This small commit just adds a bit of text beside the overriding option in
Block Sets notifying users that there is another setting that must also be enabled.

If we wanted to be less intrusive, we could have the warning only be
visible if the "allow override" option is checked. I figured it would be
better to opt for the simplest solution first though.