### PR TITLE
Make multiple block sets and filters work together

### DIFF
--- a/content.js
+++ b/content.js
@@ -113,19 +113,24 @@ function checkKeyword(keywordRE) {
 	return false; // keyword(s) not found
 }
 
-// Apply filter
+// Apply filters
 //
-function applyFilter(name) {
-	let filters = {
-		"blur (1px)": "blur(1px)",
-		"blur (2px)": "blur(2px)",
-		"blur (4px)": "blur(4px)",
-		"grayscale": "grayscale(100%)",
-		"invert": "invert(100%)",
-		"sepia": "sepia(100%)"
-	};
-	if (name && filters[name]) {
-		document.body.style.filter = filters[name];
+function applyFilters(filters) {
+	let filterString = "";
+	if (filters.blur > 0) {
+		filterString += "blur(" + filters.blur.toString() + "px) ";
+	}
+	if (filters.invert) {
+		filterString += "invert(100%) ";
+	}
+	if (filters.grayscale) {
+		filterString += "grayscale(100%) ";
+	}
+	if (filters.sepia) {
+		filterString += "sepia(100%) ";
+	}
+	if (filterString != "") {
+		document.body.style.filter = filterString;
 	} else {
 		document.body.style.filter = "none";
 	}
@@ -142,7 +147,7 @@ function handleMessage(message, sender, sendResponse) {
 		let keyword = checkKeyword(message.keywordRE);
 		sendResponse(keyword);
 	} else if (message.type == "filter") {
-		applyFilter(message.name);
+		applyFilters(message.filters);
 	}
 }
 


### PR DESCRIPTION
Per my request, you recently implemented the removing of filters after blocking conditions no longer apply, which I really appreciate :)

Unluckily, it had the side effect of making filters stop working when multiple block sets were involved, because a filter applied by one of them would immediately be removed by another :P

But based on your commit, I could at least see where the relevant code is now.

This pull request makes it so filters aren't applied directly while iterating through the block sets, but collected separately and applied at the end. Multiple filters get "unioned" so e.g. there is only one invert filter at a time, and the highest blur filter wins. There is some complication from needing to support both `activeBlock` and non-`activeBlock` block sets.

I've lightly tested on a "seems to work" basis, but there are a ton of knobs so I dunno if there's anything else it might interact with.