### PR TITLE
Unblock a ruleset for a specified duration after delay countdown

### DIFF
--- a/background.js
+++ b/background.js
@@ -484,7 +484,8 @@ function checkTab(id, url, isRepeat) {
 			let override = (overrideEndTime > now) && allowOverride;
 
 			// Check if the set has been allowed after a delay
-			let delayAllowSet = gOptions[`delayAllowedEndTimes${set}`] && gOptions[`delayAllowedEndTimes${set}`] > now;
+			let delayAllowSetEndTime = gOptions[`delayAllowedEndTimes${set}`];
+			let delayAllowSet = delayAllowSetEndTime && delayAllowSetEndTime > now;
 
 			// Determine whether this page should now be blocked
 			let doBlock = lockdown
@@ -559,7 +560,7 @@ function checkTab(id, url, isRepeat) {
 				secsLeft = Math.max(secsLeft, overrideEndTime - now);
 			}
 			if (delayAllowSet) {
-				secsLeft = Math.max(secsLeft, gOptions[`delayAllowedEndTimes${set}`] - now);
+				secsLeft = Math.max(secsLeft, delayAllowSetEndTime - now);
 			}
 			if (showTimer && secsLeft < gTabs[id].secsLeft) {
 				gTabs[id].secsLeft = secsLeft;
@@ -1146,14 +1147,6 @@ function openDelayedPage(id, url, set, pickedAllowSecs) {
 		} else {
 			warn("Did not recognize selected delay method");
 		}
-
-		// Test this:
-		// What about overlapping unblocks (in different tabs)? What happens then?
-		// What about more than one ruleset?
-		// What about existing normal blocking schedule?
-		// What about override?
-		
-		// Maybe add a button to clear the unblock.
 	}
 
 	// Redirect page

--- a/background.js
+++ b/background.js
@@ -862,6 +862,9 @@ function createBlockInfo(url) {
 	// Get whether a duration should be selected by the user after the delay
 	let delayPickDuration = gOptions[`delayMethod${blockedSet}`] == "setTimer";
 
+	// Get the max duration that can be selected
+	let delayMaxDuration = gOptions[`delayAllowMaxDuration${blockedSet}`]
+
 	// Get reloading time (if specified)
 	let reloadSecs = gOptions[`reloadSecs${blockedSet}`];
 
@@ -873,6 +876,7 @@ function createBlockInfo(url) {
 		unblockTime: unblockTime,
 		delaySecs: delaySecs,
 		delayPickDuration: delayPickDuration,
+		delayMaxDuration: delayMaxDuration,
 		reloadSecs: reloadSecs
 	};
 }

--- a/blocked.js
+++ b/blocked.js
@@ -56,8 +56,11 @@ function processBlockInfo(info) {
 	}
 
 	let durationSelect = document.getElementById("durationSelect");
-	if (info.delayPickDuration && durationSelect) {
+	if (info.delayPickDuration && info.delayMaxDuration && durationSelect) {
 		durationSelect.onchange = function() { pickDuration(this.value); };
+
+		// Right now the select just contains the null element so fill it up with options
+		addDelayAllowDurationsToSelectElement(durationSelect, info.delayMaxDuration);
 	}
 
 	let delaySecs = document.getElementById("lbDelaySeconds");

--- a/common.js
+++ b/common.js
@@ -13,6 +13,17 @@ const PARSE_URL = /^((([\w-]+):\/*(\w+(?::\w+)?@)?([\w-\.]+)(?::(\d*))?)([^\?#]*
 
 const LEECHBLOCK_URL = "https://www.proginosko.com/leechblock/";
 
+const DELAY_ALLOW_DURATIONS = [
+	{ minutes: 5,  text: "5 minutes" },
+	{ minutes: 10, text: "10 minutes" },
+	{ minutes: 15, text: "15 minutes" },
+	{ minutes: 30, text: "30 minutes" },
+	{ minutes: 60, text: "1 hour (60 minutes)" },
+	{ minutes: 90, text: "1.5 hours (90 minutes)" },
+	{ minutes: 120, text: "2 hours (120 minutes)" },
+	{ minutes: 180, text: "3 hours (180 minutes)" }
+];
+
 const PER_SET_OPTIONS = {
 	// def: default value, id: form element identifier (see options.html)
 	setName: { type: "string", def: "", id: "setName" },
@@ -30,6 +41,7 @@ const PER_SET_OPTIONS = {
 	activeBlock: { type: "boolean", def: false, id: "activeBlock" },
 	countFocus: { type: "boolean", def: true, id: "countFocus" },
 	delayMethod: { type: "string", def: "consecutive", id: "delayMethod" },
+	delayAllowMaxDuration: { type: "string", def: "60", id: "delayAllowMaxDuration" },
 	delaySecs: { type: "string", def: "60", id: "delaySecs" },
 	reloadSecs: { type: "string", def: "", id: "reloadSecs" },
 	allowOverride: { type: "boolean", def: false, id: "allowOverride" },
@@ -383,6 +395,18 @@ function getTimePeriodStart(now, limitPeriod, limitOffset) {
 	}
 
 	return 0;
+}
+
+// Add new options for each duration in DELAY_ALLOW_DURATIONS into a select element up to limitMins
+//
+function addDelayAllowDurationsToSelectElement(selectElem, limitMins) {
+	for (let duration of DELAY_ALLOW_DURATIONS) {
+		if (limitMins && duration.minutes > limitMins) break;
+		let option = document.createElement("option");
+		option.value = "" + duration.minutes;
+		option.text = duration.text;
+		selectElem.add(option);
+	}
 }
 
 // Format a time in seconds to HH:MM:SS format

--- a/common.js
+++ b/common.js
@@ -29,7 +29,7 @@ const PER_SET_OPTIONS = {
 	filterName: { type: "string", def: "grayscale", id: "filterName" },
 	activeBlock: { type: "boolean", def: false, id: "activeBlock" },
 	countFocus: { type: "boolean", def: true, id: "countFocus" },
-	delayFirst: { type: "boolean", def: true, id: "delayFirst" },
+	delayMethod: { type: "string", def: "consecutive", id: "delayMethod" },
 	delaySecs: { type: "string", def: "60", id: "delaySecs" },
 	reloadSecs: { type: "string", def: "", id: "reloadSecs" },
 	allowOverride: { type: "boolean", def: false, id: "allowOverride" },

--- a/delayed.html
+++ b/delayed.html
@@ -41,12 +41,7 @@
 			<p id="pickDuration" style="display: none;">
 				Allow pages in this set for <select id="durationSelect">
 					<option value=""></option>
-					<option value="5">5 minutes</option>
-					<option value="10">10 minutes</option>
-					<option value="15">15 minutes</option>
-					<option value="30">30 minutes</option>
-					<option value="45">45 minutes</option>
-					<option value="60">1 hour</option>
+					<!-- populate with the rest later -->
 				</select>
 			</p>
 		</div>
@@ -58,6 +53,7 @@
 			<a href="https://addons.mozilla.org/en-US/firefox/addon/leechblock-ng/">writing a review</a>.
 		</div>
 
+		<script src="common.js"></script>
 		<script src="blocked.js"></script>
 
 	</body>

--- a/delayed.html
+++ b/delayed.html
@@ -26,10 +26,29 @@
 		</div>
 
 		<!-- blocked site info -->
-		<div>
+		<div id="blockedInfo">
 			<a id="lbBlockedURLLink" target="_self"><span id="lbBlockedURL"></span></a>
 			(<span id="lbBlockedSet">Block Set</span>)
-			<p id="lbCountdownText">The page will be loaded in <strong><span id="lbDelaySeconds">0</span></strong> second(s).</p>
+
+			<p id="lbCountdownText">
+				The page will be
+				<span id="lbLoaded">loaded</span>
+				<span id="lbAvailable" style="display: none;">available</span>
+				in <strong><span id="lbDelaySeconds">0</span></strong> second(s).
+			</p>
+
+			<!-- allow duration selection after delay -->
+			<p id="pickDuration" style="display: none;">
+				Allow pages in this set for <select id="durationSelect">
+					<option value=""></option>
+					<option value="5">5 minutes</option>
+					<option value="10">10 minutes</option>
+					<option value="15">15 minutes</option>
+					<option value="30">30 minutes</option>
+					<option value="45">45 minutes</option>
+					<option value="60">1 hour</option>
+				</select>
+			</p>
 		</div>
 
 		<!-- support info -->

--- a/options.html
+++ b/options.html
@@ -154,8 +154,11 @@
 								<label for="countFocus1">Count time spent on these sites only when browser tab is active</label>
 							</p>
 							<p>
-								<input id="delayFirst1" type="checkbox">
-								<label for="delayFirst1">Block only first accessed page of site when delaying page is used</label>
+								Allow pages after a delay by <select id="delayMethod1">
+									<option value="consecutive">unblocking any consecutive accesses on the domain</option>
+									<option value="first">only unblocking the first accessed page</option>
+									<option value="setTimer">unblocking the block set for a specified duration</option>
+								</select> when delaying page is used
 							</p>
 							<p>
 								Delay access to sites by <input id="delaySecs1" type="text" size="2"> seconds when delaying page is used

--- a/options.html
+++ b/options.html
@@ -161,6 +161,9 @@
 								</select> when delaying page is used
 							</p>
 							<p>
+								When unblocking the block set for a specified duration, limit duration to <select id="delayAllowMaxDuration1"></select>
+							</p>
+							<p>
 								Delay access to sites by <input id="delaySecs1" type="text" size="2"> seconds when delaying page is used
 							</p>
 							<p>

--- a/options.js
+++ b/options.js
@@ -55,6 +55,7 @@ function initForm(numSets) {
 		$(`#defaultPage${set}`).click(function (e) { $(`#blockURL${set}`).val(DEFAULT_BLOCK_URL); });
 		$(`#delayingPage${set}`).click(function (e) { $(`#blockURL${set}`).val(DELAYED_BLOCK_URL); });
 		$(`#blankPage${set}`).click(function (e) { $(`#blockURL${set}`).val("about:blank"); });
+		addDelayAllowDurationsToSelectElement($(`#delayAllowMaxDuration${set}`)[0]);
 		$(`#resetOpts${set}`).click(function (e) {
 			resetSetOptions(set);
 			$("#alertResetOptions").dialog("open");


### PR DESCRIPTION
This PR adds the option to have a ruleset unblocked for a user-selected duration after the delay page finishes counting. The max duration can be selected as a per-ruleset setting as well. This should work in tandem with the normal blocking schedule in the same way that the override does.

**Why:** This makes it possible to use LeechBlock in a similar manner as the many extensions that have popped up that focus on just delaying page access (DelayWebpage, Delay, Mindful Internet Use and so on). The existing model doesn't work too well for that purpose since either all following page accesses on the domain are allowed indefinitely (too permissive) or only the very first page is allowed (too restrictive). The former option also does not let one use the site in another tab or navigate away from the domain and back which can be frustrating. I have seen at least one other person complain about the lack of this feature (see [this Hacker News thread](https://news.ycombinator.com/item?id=22320267)) and I'm sure there are others. I think it's a great addition because LeechBlock has a host of features the other extensions don't have and it runs everywhere.

**Possible issues:** The only issue I see at the moment is that user preferences would not be preserved with this change. The default behaviour of the delay page is unchanged but what was previously a checkbox is now a combobox, so if a user unchecked the "block only first accessed page" option and they updated to this patch the extension would revert to default behaviour until they go back and change it. Not sure how you would deal with this—I suppose one could migrate the old setting to the new one in the setup code.

Not sure how you feel about this, but that's what the PR is for. Thanks for your work on the extension :).
