### PR TITLE
Increase size of duration inputs in lockdown.html

### DIFF
--- a/lockdown.html
+++ b/lockdown.html
@@ -24,7 +24,7 @@
 					<p>
 						<label>Enter the duration of the lockdown:</label><br>
 						<div>
-							<input id="hours" type="text" size="2" list="hours-list">
+							<input id="hours" type="text" size="5" list="hours-list">
 							<datalist id="hours-list">
 								<option value="1">
 								<option value="2">
@@ -38,7 +38,7 @@
 							</datalist>
 							<label for="hours">hour(s)</label>
 							&nbsp;&nbsp;&nbsp;&nbsp;
-							<input id="mins" type="text" size="2" list="mins-list">
+							<input id="mins" type="text" size="5" list="mins-list">
 							<datalist id="mins-list">
 								<option value="5">
 								<option value="10">


### PR DESCRIPTION
The hours and minutes fields on the lockdown page were previously too small to type into. This PR increases their widths from 2 to 5 characters.