### PR TITLE
Add option to prevent access to options early

### DIFF
--- a/options.html
+++ b/options.html
@@ -210,6 +210,10 @@
 								<label for="prevOpts1">Prevent access to options for this block set at times when these sites are blocked</label>
 							</p>
 							<p>
+								<input id="prevOffToggle1" type="checkbox">
+								<label for="prevOffToggle1">Prevent access to options for this block set <input id="prevOffset1" type="text" size="2" title="Leave blank for no offset"> minutes early/late</label>
+							</p>
+							<p>
 								<input id="prevGenOpts1" type="checkbox">
 								<label for="prevGenOpts1">Prevent access to General options at times when these sites are blocked</label>
 							</p>

--- a/options.js
+++ b/options.js
@@ -127,6 +127,7 @@ function saveOptions(event) {
 		let delaySecs = $(`#delaySecs${set}`).val();
 		let reloadSecs = $(`#reloadSecs${set}`).val();
 		let blockURL = $(`#blockURL${set}`).val();
+		let optBlockOffset = $(`#prevOffset${set}`).val();
 
 		// Check field values
 		if (!checkTimePeriodsFormat(times)) {
@@ -164,6 +165,12 @@ function saveOptions(event) {
 			$("#tabs").tabs("option", "active", (set - 1));
 			$(`#blockURL${set}`).focus();
 			$("#alertBadBlockURL").dialog("open");
+			return false;
+		}
+		if (!checkPosIntFormat(optBlockOffset)) {
+			$("#tabs").tabs("option", "active", (set - 1));
+			$(`#prevOffset${set}`).focus();
+			$("#alertBadSeconds").dialog("open");
 			return false;
 		}
 	}
@@ -393,9 +400,18 @@ function retrieveOptions() {
 			let periodStart = getTimePeriodStart(now, limitPeriod, limitOffset);
 			let conjMode = options[`conjMode${set}`];
 			let days = options[`days${set}`];
+			let blockOffToggle = options[`prevOffToggle${set}`];
+			let blockOffset = options[`prevOffset${set}`];
 
 			// Check day
 			let onSelectedDay = days[timedate.getDay()];
+
+			if(blockOffToggle && blockOffset) {
+				minPeriods = getExtendedMinPeriods(times, blockOffset);
+				times = minPeriodsToString(minPeriods);
+
+				limitMins = limitMins ? limitMins - blockOffset : limitMins;
+			}
 
 			// Check time periods
 			let withinTimePeriods = false;


### PR DESCRIPTION
Unless you lock up the whole extension, there currently isn't a way to allow a set of sites without allowing that set to be edited.
This PR adds a way to lock option sets a certain amount of time before the set goes into effect.

It should™ work in its current state, but let me know if you want anything changed.

Potential issues:
- Its easy to permanently lock an option set. I don't know the best way to handle this, as the issue is not unique to this.
- It might act strangely on blocked days bordered by unblocked days. Probably fixable, if I change how certain things work.