### PR TITLE
Fix race condition with block check occurring before the referrer is loaded

### DIFF
--- a/background.js
+++ b/background.js
@@ -37,7 +37,8 @@ function initTab(id) {
 			allowedPath: null,
 			allowedSet: 0,
 			referrer: "",
-			url: "about:blank"
+			url: "about:blank",
+			loaded: false
 		};
 		return true;
 	}
@@ -362,10 +363,12 @@ function processTabs(active) {
 			clockPageTime(tab.id, false, false);
 			clockPageTime(tab.id, true, focus);
 
-			let blocked = checkTab(tab.id, false, true);
-
-			if (!blocked && tab.active) {
-				updateTimer(tab.id);
+			if (gTabs[tab.id].loaded) {
+				let blocked = checkTab(tab.id, false, true);
+	
+				if (!blocked && tab.active) {
+					updateTimer(tab.id);
+				}
 			}
 		}
 	}
@@ -1328,6 +1331,11 @@ function handleMessage(message, sender, sendResponse) {
 			sendResponse();
 			break;
 
+		case "loaded":
+			// Register that content script has been loaded
+			gTabs[sender.tab.id].loaded = true;
+			break;
+
 	}
 }
 
@@ -1422,6 +1430,7 @@ function handleBeforeNavigate(navDetails) {
 	clockPageTime(tabId, false, false);
 
 	if (navDetails.frameId == 0) {
+		gTabs[tabId].loaded = false
 		gTabs[tabId].url = navDetails.url;
 
 		let blocked = checkTab(tabId, true, false);

--- a/content.js
+++ b/content.js
@@ -173,3 +173,6 @@ browser.runtime.onMessage.addListener(handleMessage);
 
 // Send URL of referring page to background script
 browser.runtime.sendMessage({ type: "referrer", referrer: document.referrer });
+
+// Register that this script has now loaded
+browser.runtime.sendMessage({ type: "loaded" });


### PR DESCRIPTION
This fixes a race condition that can occur with the referrer not being set in time.

The referrer header can be used as an exception to allow access to a page that would otherwise be blocked. The `content.js` script which runs on the page being loaded is responsible for grabbing the referrer and sending it to `background.js` where it is used to determine if a page should be blocked or not. `background.js` has interval timer which checks to see if a page should be blocked every second. If someone loads a page is on the list of domains that should be blocked and this interval timer runs before `content.js` has a chance to set the referrer in the `gTabs[tab.id]` data structure then the page will be blocked without checking the page referrer. 

This is an issue because the user could have a referrer setup which would otherwise have allowed them to view this page.

This PR fixes that by setting a `loaded` flag to true only after `content.js` has initially finished executing.