### PR TITLE
Add option to override using a predefined access code

### DIFF
--- a/common.js
+++ b/common.js
@@ -79,6 +79,7 @@ const GENERAL_OPTIONS = {
 	timerBadge: { type: "boolean", def: true, id: "timerBadge" }, // default: enabled
 	orm: { type: "string", def: "", id: "overrideMins" }, // default: no prespecified override
 	ora: { type: "string", def: "0", id: "overrideAccess" }, // default: no password or code
+	orcode: { type: "string", def: "", id: "overrideCode" }, // default: blank
 	orp: { type: "string", def: "", id: "overridePassword" }, // default: blank
 	orc: { type: "boolean", def: true, id: "overrideConfirm" }, // default: enabled
 	warnSecs: { type: "string", def: "", id: "warnSecs" }, // default: no warning

--- a/options.html
+++ b/options.html
@@ -370,9 +370,14 @@
 										<option value="2">Require the user to enter a random 32-character access code</option>
 										<option value="3">Require the user to enter a random 64-character access code</option>
 										<option value="4">Require the user to enter a random 128-character access code</option>
+										<option value="8">Require the user to enter a predefined access code (see below)</option>
 										<option value="9">Require the user to enter a separate override password (see below)</option>
 									</select>
 								</div>
+							</p>
+							<p>
+								<label>Predefined access code:</label>
+								<input id="overrideCode" type="text" size="60">
 							</p>
 							<p>
 								<label>Override password:</label>

--- a/override.js
+++ b/override.js
@@ -74,6 +74,7 @@ function closePage() {
 function confirmAccess(options) {
 	let ora = options["ora"];
 	let orp = options["orp"];
+	let code = options["orcode"];
 	let password = options["password"];
 	let hpp = options["hpp"];
 
@@ -87,6 +88,11 @@ function confirmAccess(options) {
 		$("#promptPasswordInput").val("");
 		$("#promptPassword").dialog("open");
 		$("#promptPasswordInput").focus();
+	} else if (ora == 8 && code) {
+		gAccessRequiredInput = code;
+		displayAccessCode(code, options["accessCodeImage"]);
+		$("#promptAccessCode").dialog("open");
+		$("#promptAccessCodeInput").focus();
 	} else if (ora == 9 && orp) {
 		gAccessRequiredInput = orp;
 		$("#promptPasswordInput").attr("type", "password");
@@ -122,6 +128,19 @@ function displayAccessCode(code, asImage) {
 	let codeImage = getElement("promptAccessCodeImage");
 	let codeCanvas = getElement("promptAccessCodeCanvas");
 
+	let lines = [];
+	let idx = 0;
+	do {
+		let spaceIdx = (idx + 64 >= code.length) ? code.length : code.lastIndexOf(" ", idx + 64);
+		if (spaceIdx == -1) {
+			lines.push(code.substring(idx, idx + 64));
+			idx += 64;
+		} else {
+			lines.push(code.substring(idx, spaceIdx));
+			idx = spaceIdx + 1;
+		}
+	} while (idx < code.length - 1);
+
 	if (asImage) {
 		// Display code as image
 		codeText.style.display = "none";
@@ -129,7 +148,7 @@ function displayAccessCode(code, asImage) {
 		let ctx = codeCanvas.getContext("2d");
 		ctx.font = "normal 14px monospace";
 		let width = ctx.measureText(code.substring(0, 64)).width + 8;
-		let height = (code.length == 128) ? 40 : 24;
+		let height = lines.length * 16 + 8;
 		codeCanvas.width = width * devicePixelRatio;
 		codeCanvas.height = height * devicePixelRatio;
 		ctx.scale(devicePixelRatio, devicePixelRatio);
@@ -137,22 +156,16 @@ function displayAccessCode(code, asImage) {
 		codeCanvas.style.height = height + 'px';
 		ctx.font = "normal 14px monospace"; // resizing canvas resets font!
 		ctx.fillStyle = "#000";
-		if (code.length == 128) {
-			ctx.fillText(code.substring(0, 64), 4, 16);
-			ctx.fillText(code.substring(64), 4, 32);
-		} else {
-			ctx.fillText(code, 4, 16);
+		for (let i = 0; i < lines.length; i++) {
+			ctx.fillText(lines[i], 4, 16 * (i+1));
 		}
 	} else {
 		// Display code as text
 		codeText.style.display = "";
 		codeImage.style.display = "none";
-		if (code.length == 128) {
-			codeText.appendChild(document.createTextNode(code.substring(0, 64)));
+		for (let i = 0; i < lines.length; i++) {
+			codeText.appendChild(document.createTextNode(lines[i]));
 			codeText.appendChild(document.createElement("br"));
-			codeText.appendChild(document.createTextNode(code.substring(64)));
-		} else {
-			codeText.appendChild(document.createTextNode(code));
 		}
 	}
 }

--- a/override.js
+++ b/override.js
@@ -90,7 +90,8 @@ function confirmAccess(options) {
 		$("#promptPasswordInput").focus();
 	} else if (ora == 8 && code) {
 		gAccessRequiredInput = code;
-		displayAccessCode(code, options["accessCodeImage"]);
+		numLines = displayAccessCode(code, options["accessCodeImage"]);
+		resizePromptInputHeight(numLines);
 		$("#promptAccessCode").dialog("open");
 		$("#promptAccessCodeInput").focus();
 	} else if (ora == 9 && orp) {
@@ -108,7 +109,8 @@ function confirmAccess(options) {
 			code += createAccessCode(64);
 		}
 		gAccessRequiredInput = code;
-		displayAccessCode(code, options["accessCodeImage"]);
+		numLines = displayAccessCode(code, options["accessCodeImage"]);
+		resizePromptInputHeight(numLines);
 		$("#promptAccessCodeInput").val("");
 		$("#promptAccessCode").dialog("open");
 		$("#promptAccessCodeInput").focus();
@@ -168,6 +170,22 @@ function displayAccessCode(code, asImage) {
 			codeText.appendChild(document.createElement("br"));
 		}
 	}
+
+	return lines.length;
+}
+
+// Convert #promptAccessCodeInput to a textarea and resize its height based
+// on the number of lines of the access code
+//
+function resizePromptInputHeight(numLines) {
+	if (numLines < 2) return;
+	let codeInput = getElement("promptAccessCodeInput");
+	let textarea = document.createElement("textarea");
+	textarea.id = codeInput.id;
+	textarea.font = codeInput.font;
+	textarea.rows = numLines;
+	textarea.cols = codeInput.size;
+	codeInput.replaceWith(textarea);
 }
 
 // Activate override


### PR DESCRIPTION
I wanted an option to temporarily override filters using a predefined access code, which is a middle ground between random access code and a password:
1. It's visible like a random access code so the user can read and type it out
2. It's predefined like a password

I wanted this option so I can type out a meaningful message to override
<img width="611" alt="Override" src="https://user-images.githubusercontent.com/1325902/177462242-4d16b67f-7bb4-4636-af80-b97b9286428a.png">
Also, since a input text field doesn't support word wrapping, I convert it to a text area when necessary.

I added a second text field to the General config for this option:
<img width="665" alt="Options" src="https://user-images.githubusercontent.com/1325902/177462385-83607a66-f023-47b1-b5a2-0930d2b780e5.png">

If this pull request gets merged, then I can set one up for LeechBlockNG-chrome as well, which has a one line difference to get the text area text and displayed access code to line up.