### PR TITLE
Added possibility to set multiple options to show instead of blocked …

### DIFF
--- a/background.js
+++ b/background.js
@@ -528,7 +528,7 @@ function checkTab(id, isBeforeNav, isRepeat) {
 			let rollover = gOptions[`rollover${set}`];
 			let conjMode = gOptions[`conjMode${set}`];
 			let days = gOptions[`days${set}`];
-			let blockURL = gOptions[`blockURL${set}`];
+			let blockURLs = gOptions[`blockURLs${set}`];
 			let applyFilter = gOptions[`applyFilter${set}`];
 			let filterName = gOptions[`filterName${set}`];
 			let filterMute = gOptions[`filterMute${set}`];
@@ -605,7 +605,7 @@ function checkTab(id, isBeforeNav, isRepeat) {
 						log(`lockdown: ${lockdown}`);
 						log(`withinTimePeriods: ${withinTimePeriods}`);
 						log(`afterTimeLimit: ${afterTimeLimit}`);
-						log(`blockURL: ${blockURL}`);
+						log(`blockURLs: ${blockURLs}`);
 						if (blockRE) {
 							let res = blockRE.exec(pageURL);
 							if (res) {
@@ -644,11 +644,16 @@ function checkTab(id, isBeforeNav, isRepeat) {
 					} else {
 						gTabs[id].keyword = keyword;
 
+						let blockUrlsList = blockURLs.split("\n");
+						let positionOfBlockUrlToRedirectOn = Math.floor(Math.random() * (blockUrlsList.length));
+
+						let blockURL = blockUrlsList[positionOfBlockUrlToRedirectOn];	
+						
 						// Get final URL for block page
 						blockURL = getLocalizedURL(blockURL)
-								.replace(/\$K/g, keyword ? keyword : "")
-								.replace(/\$S/g, set)
-								.replace(/\$U/g, pageURLWithHash);
+							.replace(/\$K/g, keyword ? keyword : "")
+							.replace(/\$S/g, set)
+							.replace(/\$U/g, pageURLWithHash);
 
 						// Redirect page
 						browser.tabs.update(id, { url: blockURL });

--- a/common.js
+++ b/common.js
@@ -37,7 +37,7 @@ const PER_SET_OPTIONS = {
 	rollover: { type: "boolean", def: false, id: "rollover" },
 	conjMode: { type: "boolean", def: false, id: "conjMode" },
 	days: { type: "array", def: [false, true, true, true, true, true, false], id: "day" },
-	blockURL: { type: "string", def: DEFAULT_BLOCK_URL, id: "blockURL" },
+	blockURLs: { type: "string", def: DEFAULT_BLOCK_URL, id: "blockURLs" },
 	applyFilter: { type: "boolean", def: false, id: "applyFilter" },
 	filterName: { type: "string", def: "grayscale", id: "filterName" },
 	filterMute: { type: "boolean", def: false, id: "filterMute" },
@@ -316,8 +316,12 @@ function checkPosNegIntFormat(value) {
 
 // Check blocking page URL format
 //
-function checkBlockURLFormat(url) {
-	return INTERNAL_BLOCK_URL.test(url) || getParsedURL(url).page;
+function checkBlockURLsFormat(url) {
+	let listOfUrls = url.split("\n");
+	for(let i = 0; i < listOfUrls.length; ++i)
+		if(!INTERNAL_BLOCK_URL.test(listOfUrls[i]) && !getParsedURL(listOfUrls[i]).page)
+			return false;
+	return true;
 }
 
 // Convert times to minute periods

--- a/options.css
+++ b/options.css
@@ -87,6 +87,28 @@ body {
 	width: 408px;
 }
 
+.whatToShowInsteadOfBlocked {
+	display: flex;
+	padding-top: 7px;
+	padding-bottom: 7px;
+}
+
+.listOfSites {
+	float: left;
+	padding-right: 5%;
+}
+
+.predefinedOptionsList {
+	display: flex;
+	flex-direction: column;
+}
+
+.predefinedOption {
+	display: flex;
+	justify-content: space-between;
+	padding: 3px;
+}
+
 #form-container {
 	display: flex;
 	justify-content: center;

--- a/options.html
+++ b/options.html
@@ -135,18 +135,40 @@
 								<em>In this section, specify how you want to block these sites.</em>
 							</p>
 							<hr>
+
 							<p>
 								<label>Enter the fully specified URL of the page to show instead of these blocked sites:</label>
-								<div><input id="blockURL1" type="text" size="60" placeholder="http://somesite.com/somepage.html" title="Use $U to pass URL of blocked page"></div>
 							</p>
 							<p>
-								<div>
-									<label>Predefined URLs:</label>
-									<button id="defaultPage1" type="button">Default Page</button>
-									<button id="delayingPage1" type="button">Delaying Page</button>
-									<button id="blankPage1" type="button">Blank Page</button>
-								</div>
+								<label>(If you enter multiple pages each in new line, one of them will be every time randomly selected to show instead of these blocked sites)</label>
 							</p>
+							<div class="whatToShowInsteadOfBlocked">
+								<div class="listOfSites">
+									<textarea id="blockURLs1" cols="60" rows="10" spellcheck="false" placeholder="http://somesite.com/somepage.html" title="Use $U to pass URL of blocked page"></textarea>
+								</div>
+
+								<div class="predefinedOptionsList">
+									<label>Add predefined URLs:</label>
+
+									<div class="predefinedOption">
+										<button id="removeDefaultPage1" type="button">-</button>
+										<div>Default Page</div>
+										<button id="addDefaultPage1" type="button">+</button>
+									</div>
+									<div class="predefinedOption">
+										<button id="removeDelayingPage1" type="button">-</button>
+										<div>Delaying Page</div>
+										<button id="addDelayingPage1" type="button">+</button>
+									</div>
+									<div class="predefinedOption">										
+										<button id="removeBlankPage1" type="button">-</button>
+										<div>Blank Page</div>
+										<button id="addBlankPage1" type="button">+</button>
+									</div>
+
+								</div>
+							</div>
+
 							<hr>
 							<p>
 								<input id="applyFilter1" type="checkbox">
@@ -533,7 +555,7 @@
 			<div id="alertBadMinutes" title="LeechBlock Options">
 				<p>Please enter the number of minutes in the correct format (as a positive whole number).</p>
 			</div>
-			<div id="alertBadBlockURL" title="LeechBlock Options">
+			<div id="alertBadBlockURLs" title="LeechBlock Options">
 				<p>Please enter the URL for the blocking page in the correct format (as a fully specified URL).</p>
 			</div>
 			<div id="alertBadNumSets" title="LeechBlock Options">

--- a/options.js
+++ b/options.js
@@ -73,9 +73,12 @@ function initForm(numSets) {
 		});
 		$(`#setName${set}`).change(function (e) { updateBlockSetName(set, $(`#setName${set}`).val()); });
 		$(`#allDay${set}`).click(function (e) { $(`#times${set}`).val(ALL_DAY_TIMES); });
-		$(`#defaultPage${set}`).click(function (e) { $(`#blockURL${set}`).val(DEFAULT_BLOCK_URL); });
-		$(`#delayingPage${set}`).click(function (e) { $(`#blockURL${set}`).val(DELAYED_BLOCK_URL); });
-		$(`#blankPage${set}`).click(function (e) { $(`#blockURL${set}`).val("about:blank"); });
+		$(`#addDefaultPage${set}`).click(function (e) { addToListOfBlockUrls(DEFAULT_BLOCK_URL, set); });
+		$(`#addDelayingPage${set}`).click(function (e) { addToListOfBlockUrls(DELAYED_BLOCK_URL, set); });
+		$(`#addBlankPage${set}`).click(function (e) { addToListOfBlockUrls("about:blank", set); });
+		$(`#removeDefaultPage${set}`).click(function (e) { removeFromListOfBlockUrls(DEFAULT_BLOCK_URL, set); });
+		$(`#removeDelayingPage${set}`).click(function (e) { removeFromListOfBlockUrls(DELAYED_BLOCK_URL, set); });
+		$(`#removeBlankPage${set}`).click(function (e) { removeFromListOfBlockUrls("about:blank", set); });
 		$(`#resetOpts${set}`).click(function (e) {
 			resetSetOptions(set);
 			$("#alertResetOptions").dialog("open");
@@ -178,7 +181,7 @@ function saveOptions(event) {
 		let limitOffset = $(`#limitOffset${set}`).val();
 		let delaySecs = $(`#delaySecs${set}`).val();
 		let reloadSecs = $(`#reloadSecs${set}`).val();
-		let blockURL = $(`#blockURL${set}`).val();
+		let blockURLs = $(`#blockURLs${set}`).val();
 
 		// Check field values
 		if (!checkTimePeriodsFormat(times)) {
@@ -211,10 +214,10 @@ function saveOptions(event) {
 			$("#alertBadSeconds").dialog("open");
 			return false;
 		}
-		if (!checkBlockURLFormat(blockURL)) {
+		if (!checkBlockURLsFormat(blockURLs)) {
 			$("#tabs").tabs("option", "active", (set - 1));
-			$(`#blockURL${set}`).focus();
-			$("#alertBadBlockURL").dialog("open");
+			$(`#blockURLs${set}`).focus();
+			$("#alertBadBlockURLs").dialog("open");
 			return false;
 		}
 	}
@@ -996,7 +999,8 @@ function disableSetOptions(set, disabled) {
 	let items = [
 		"resetOpts",
 		"allDay",
-		"defaultPage", "delayingPage", "blankPage",
+		"addDefaultPage", "addDelayingPage", "addBlankPage",
+		"removeDefaultPage", "removeDelayingPage", "removeBlankPage",
 		"clearRegExpBlock", "genRegExpBlock",
 		"clearRegExpAllow", "genRegExpAllow",
 		"cancelLockdown"
@@ -1095,6 +1099,18 @@ function handleKeyDown(event) {
 			$("#saveOptionsClose").click();
 		}
 	}
+}
+
+function removeFromListOfBlockUrls(urlToRemove, set) {
+	let listOfBlockUrls = $(`#blockURLs${set}`).val().split("\n");
+	let indexToRemove = listOfBlockUrls.indexOf(urlToRemove);
+	if(indexToRemove >= 0)
+		listOfBlockUrls.splice(indexToRemove, 1);
+	$(`#blockURLs${set}`).val(listOfBlockUrls.join("\n"));
+}
+
+function addToListOfBlockUrls(urlToAdd, set) {
+	$(`#blockURLs${set}`).val($(`#blockURLs${set}`).val() + "\n" + urlToAdd);
 }
 
 /*** STARTUP CODE BEGINS HERE ***/


### PR DESCRIPTION
This PR adds the possibility to specify many URLs to show instead of blocked pages. Every time when a user goes to a page from the block list - the block page will be shown randomly from the specified list.

**Example:**
I have a delay for opening YouTube. Now I can add specify multiple options to show instead of blocked pages:
delay page, Duolingo, and two times my task list in notion.
So when I'll go to YouTube, I'll be redirected to the delay page in 25% of cases, to Duolingo in 25% of cases, and to Notion in 50% of cases.

**Why:**
It's good to see your task list when you are going to go to some distracting page.
I think a better solution will be redirecting somewhere, showing there the delaying timer and showing a button to go to the desired page after finishing the countdown. But it's harder to implement.

**Possible issues:** The only issue I see is that people who actually have custom URL to redirect, will get the default value in this configuration. This issue is caused because of renaming _blockURL_ to _blockURLs_. There are no logical issues to keep the old name for _blockURL_, but the name can be a bit misleading.

**What I have changed:**
+element blockURL is a multiline textbox now.
+instead of buttons "Default Page", "Delaying Page", and "Blank Page" there are plus and minus buttons for each of these standard options. Plus button adds to blockURLs one line of the standard option. Minus button - removes one line.
+each time when you go to the site from the block list, you will be redirected to randomly selected one of the options from blockURLs list.

If you will have any remarks, or questions to my PR, please let me know. I'll fix it or answer it)
