### PR TITLE
Autofocus minutes input when landing on override page

### DIFF
--- a/override.js
+++ b/override.js
@@ -33,7 +33,7 @@ function initializePage() {
 	//log("initializePage");
 
 	browser.storage.local.get("sync").then(onGotSync, onError);
-
+	$("mins").focus();
 	function onGotSync(options) {
 		if (options["sync"]) {
 			browser.storage.sync.get().then(onGot, onError);


### PR DESCRIPTION
When you land on the "Override" page, you have to either `Tab` or click the `#mins` input to begin typing a number. Considering this page contains only this form, and this is the only input for it, I think it makes sense to default the focus to this input.