### PR TITLE
Allowing decimal time limits

### DIFF
--- a/common.js
+++ b/common.js
@@ -319,7 +319,7 @@ function checkPosNegIntFormat(value) {
 
 // Check positive number format (including decimals as well as whole numbers, except 0)
 //
-function isPosNumberFormat(value) {
+function checkPosNumberFormat(value) {
   return (value == "") || /^(0\.\d+|[1-9]\d*(\.\d+)?)$/.test(value);
 }
 

--- a/common.js
+++ b/common.js
@@ -317,6 +317,12 @@ function checkPosNegIntFormat(value) {
 	return (value == "") || /^-?[1-9][0-9]*$/.test(value);
 }
 
+// Check positive number format (including decimals as well as whole numbers, except 0)
+//
+function isPosNumberFormat(value) {
+  return (value == "") || /^(0\.\d+|[1-9]\d*(\.\d+)?)$/.test(value);
+}
+
 // Check blocking page URL format
 //
 function checkBlockURLFormat(url) {

--- a/options.html
+++ b/options.html
@@ -540,7 +540,7 @@
 				a dash (-) between start time and end time, and commas or spaces to separate time periods.</p>
 			</div>
 			<div id="alertBadTimeLimit" title="LeechBlock Options">
-				<p>Please enter the time limit in the correct format (as a positive whole number).</p>
+				<p>Please enter the time limit in the correct format (as a positive number).</p>
 			</div>
 			<div id="alertBadTimeLimitOffset" title="LeechBlock Options">
 				<p>Please enter the time limit offset in the correct format (as a non-zero integer).</p>

--- a/options.js
+++ b/options.js
@@ -195,7 +195,7 @@ function saveOptions(event) {
 			$("#alertBadTimes").dialog("open");
 			return false;
 		}
-		if (!checkPosIntFormat(limitMins)) {
+		if (!isPosNumberFormat(limitMins)) {
 			$("#tabs").tabs("option", "active", (set - 1));
 			$(`#limitMins${set}`).focus();
 			$("#alertBadTimeLimit").dialog("open");

--- a/options.js
+++ b/options.js
@@ -195,7 +195,7 @@ function saveOptions(event) {
 			$("#alertBadTimes").dialog("open");
 			return false;
 		}
-		if (!isPosNumberFormat(limitMins)) {
+		if (!checkPosNumberFormat(limitMins)) {
 			$("#tabs").tabs("option", "active", (set - 1));
 			$(`#limitMins${set}`).focus();
 			$("#alertBadTimeLimit").dialog("open");


### PR DESCRIPTION
**Problem:** 
There's some cases where you really need to block for less than a minute per time period but you can't because you're arbitrarily limited at only positive _whole_ numbers (e.g. 1 minute, but not 0.3 minutes, 0.5 minutes, etc).

**Solution:**
This minimally invasive PR solves this by checking that the string used for time limits is a positive number (not including 0, like before) but including decimal numbers. 

I tested it on a dev version of the extension and works great. Feel free to test the boolean regex here (compares with the old): https://jsfiddle.net/aos4t7L6/

@proginosko 