### PR TITLE
Add YT video resume option

### DIFF
--- a/background.js
+++ b/background.js
@@ -575,6 +575,7 @@ function checkTab(id, isBeforeNav, isRepeat) {
 			let allowOverLock = gOptions[`allowOverLock${set}`];
 			let showTimer = gOptions[`showTimer${set}`];
 			let allowKeywords = gOptions[`allowKeywords${set}`];
+			let youtubeResume = gOptions[`youtubeResume${set}`];
 
 			updateRolloverTime(timedata, limitMins, limitPeriod, periodStart);
 
@@ -683,19 +684,46 @@ function checkTab(id, isBeforeNav, isRepeat) {
 					} else {
 						gTabs[id].keyword = keyword;
 
-						if (!gIsAndroid && addHistory && !isInternalPage) {
-							// Add blocked page to browser history
-							browser.history.addUrl({ url: pageURLWithHash });
+						function finalizeBlockPageRedirection() {
+							if (!gIsAndroid && addHistory && !isInternalPage) {
+								// Add blocked page to browser history
+								browser.history.addUrl({ url: pageURLWithHash });
+							}
+	
+							// Get final URL for block page
+							blockURL = getLocalizedURL(blockURL)
+									.replace(/\$K/g, keyword ? keyword : "")
+									.replace(/\$S/g, set)
+									.replace(/\$U/g, pageURLWithHash);
+	
+							// Redirect page
+							browser.tabs.update(id, { url: blockURL });
 						}
 
-						// Get final URL for block page
-						blockURL = getLocalizedURL(blockURL)
-								.replace(/\$K/g, keyword ? keyword : "")
-								.replace(/\$S/g, set)
-								.replace(/\$U/g, pageURLWithHash);
-
-						// Redirect page
-						browser.tabs.update(id, { url: blockURL });
+						const youtubeRegex = /^http(s)?:\/\/www\.youtube\.com\/watch\?v=.*$/;
+						if (youtubeRegex.test(pageURLWithHash) && youtubeResume) {
+							browser.scripting.executeScript({
+								target: { tabId: id },
+								func: () => {
+									// Get the video stream from youtube and return the current time
+									const videoElement = document.querySelector('.video-stream');
+									return videoElement ? Math.trunc(videoElement.currentTime) : 'Video element not found on the page.';
+								}
+							}).then((results) => {
+								const currentTime = results[0].result;
+								if (typeof currentTime === 'number') {
+									// Modify the URL to add or modify the "t" parameter with the time
+									const parsedUrl = new URL(pageURLWithHash);
+									const searchParams = new URLSearchParams(parsedUrl.search);
+									searchParams.set('t', currentTime);
+									parsedUrl.search = searchParams.toString();
+									pageURLWithHash = parsedUrl.toString();
+								}
+								finalizeBlockPageRedirection();
+							});
+						} else {
+							finalizeBlockPageRedirection();
+						}
 					}
 				}
 

--- a/common.js
+++ b/common.js
@@ -69,6 +69,7 @@ const PER_SET_OPTIONS = {
 	regexpBlock: { type: "string", def: "", id: "regexpBlock" },
 	regexpAllow: { type: "string", def: "", id: "regexpAllow" },
 	ignoreHash: { type: "boolean", def: true, id: "ignoreHash" },
+	youtubeResume: { type: "boolean", def: false, id: "youtubeResume" },
 };
 
 const GENERAL_OPTIONS = {

--- a/manifest.json
+++ b/manifest.json
@@ -69,7 +69,8 @@
 		"storage",
 		"tabs",
 		"unlimitedStorage",
-		"webNavigation"
+		"webNavigation",
+		"scripting"
 	],
 
 	"version": "1.6.4"

--- a/options.html
+++ b/options.html
@@ -230,6 +230,10 @@
 								<input id="allowOverLock1" type="checkbox">
 								<label for="allowOverLock1">Allow temporary override during lockdown</label>
 							</p>
+							<p class="simplifiable">
+								<input id="youtubeResume1" type="checkbox">
+								<label for="youtubeResume1">Before blocking "https://www.youtube.com/watch?v=" add the current timestamp of the video to the URL</label>
+							</p>
 						</fieldset>
 						<p>
 							<button id="resetOpts1" type="button">Reset Options to Defaults</button>


### PR DESCRIPTION
I have now implemented the feature request mentioned in https://github.com/proginosko/LeechBlockNG/discussions/425. This PR adds an option in "Show Full Options" to enable a feature that allows the extension to find the current time of a YouTube video and append it to the URL so that the video resumes from the point before the page was blocked by the extension.