### PR TITLE
added option to block about:debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.xpi
 
 jquery-ui/**
+manifest.json

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,3 +1,6 @@
+# Version 1.6.6 (17 Jul 2024)
+* Added option to block about:debugging, so that local storage attributes can't be inspected to reveal the options password
+
 # Version 1.6.5 (18 Jun 2024)
 * Added "fade (100%)" filter option.
 * Added option to disable link on blocking/delaying page.

--- a/background.js
+++ b/background.js
@@ -528,7 +528,7 @@ function checkTab(id, isBeforeNav, isRepeat) {
 				pageURL = pageURLWithHash;
 			}
 		}
-		let isInternalPage = /^about:(addons|support)/i.test(pageURL);
+		let isInternalPage = /^about:(addons|support|debugging)/i.test(pageURL);
 
 		// Get regular expressions for matching sites to block/allow
 		let blockRE = gRegExps[set].block;
@@ -547,12 +547,14 @@ function checkTab(id, isBeforeNav, isRepeat) {
 		// Get options for preventing access to about:addons and about:support
 		let prevAddons = gOptions[`prevAddons${set}`];
 		let prevSupport = gOptions[`prevSupport${set}`];
+		let prevDebugging = gOptions[`prevDebugging${set}`];
 		let prevOverride = gOptions[`prevOverride${set}`];
 
 		// Test URL against block/allow regular expressions
 		if (testURL(pageURL, referrer, blockRE, allowRE, referRE, allowRefers)
 				|| (prevAddons && /^about:addons/i.test(pageURL))
-				|| (prevSupport && /^about:support/i.test(pageURL))) {
+				|| (prevSupport && /^about:support/i.test(pageURL))
+				|| (prevDebugging && /^about:debugging/i.test(pageURL))) {
 			// Get options for this set
 			let timedata = gOptions[`timedata${set}`];
 			let times = gOptions[`times${set}`];

--- a/common.js
+++ b/common.js
@@ -59,6 +59,7 @@ const PER_SET_OPTIONS = {
 	prevGenOpts: { type: "boolean", def: false, id: "prevGenOpts" },
 	prevAddons: { type: "boolean", def: false, id: "prevAddons" },
 	prevSupport: { type: "boolean", def: false, id: "prevSupport" },
+	prevDebugging: { type: "boolean", def: false, id: "prevDebugging" },
 	prevOverride: { type: "boolean", def: false, id: "prevOverride" },
 	disable: { type: "boolean", def: false, id: "disable" },
 	showTimer: { type: "boolean", def: true, id: "showTimer" },

--- a/manifest.json
+++ b/manifest.json
@@ -19,7 +19,7 @@
 
 	"browser_specific_settings": {
 		"gecko": {
-			"id": "leechblockng@proginosko.com",
+			"id": "temporary@proginosko.com",
 			"strict_min_version": "109.0"
 		}
 	},

--- a/options.html
+++ b/options.html
@@ -279,8 +279,12 @@
 								<label for="prevSupport1">Prevent access to <strong>about:support</strong> at times when these sites are blocked</label>
 							</p>
 							<p>
+								<input id="prevDebugging1" type="checkbox">
+								<label for="prevDebugging1">Prevent access to <strong>about:debugging</strong> at times when these sites are blocked</label>
+							</p>
+							<p>
 								<input id="prevOverride1" type="checkbox">
-								<label for="prevOverride1">Allow override to apply to <strong>about:addons</strong> and <strong>about:support</strong></label>
+								<label for="prevOverride1">Allow override to apply to <strong>about:addons</strong>, <strong>about:support</strong>, and <strong>about:debugging</strong></label>
 							</p>
 							<hr>
 							<p>


### PR DESCRIPTION
In the use case that the user entrusts someone else to set a password to lock the options, they could in a moment of weakness go into about:debugging > LeechBlock > Inspect > Storage > Extension Storage and copy the password from there.  Blocking about:debugging is one solution.