### PR TITLE
Update popup.html - Fixes a small typo

### DIFF
--- a/pt_BR/popup.html
+++ b/pt_BR/popup.html
@@ -23,7 +23,7 @@
 			<button id="stats" type="button">Estatísticas</button>
 			<br><br>
 			<button id="addSites" type="button">Adicionar Site</button>
-			<button id="cancelOverride" type="button">Cancelar Suspenção</button>
+			<button id="cancelOverride" type="button">Cancelar Suspensão</button>
 			<button id="resetRollover" type="button">Zerar Tempo Acumulado</button>
 			<button id="discardTime" type="button">Descartar Tempo Restante</button>
 			<br><br>


### PR DESCRIPTION
The original translation was written "Suspenção", when the correct form is "Suspensão".