### PR TITLE
Add 30 day limit period

### DIFF
--- a/options.html
+++ b/options.html
@@ -99,6 +99,7 @@
 										<option value="345600">4 days</option>
 										<option value="604800">week (7 days)</option>
 										<option value="1209600">2 weeks (14 days)</option>
+										<option value="2592000">1 month (30 days)</option>
 									</select>
 									&nbsp;&nbsp;&nbsp;&nbsp;
 									<input id="rollover1" type="checkbox">


### PR DESCRIPTION
As of now Leechblock has lots of periods to choose for short-term blocking (like when you want to avoid websites to complete a task or have exam sessions), but it would be nice to have a couple of options for long-term blocking scenarios (like when you only want to give yourself a limited time window for a website that rarely updates, or when you are trying to break an internet habit by increasing the limit period each time as a milestone).

This PR adds an option to specify 30 days (aproximately 1 month) as a limit period, I think it is a good starting point, but 60/90 days could be nice as well.

