### PR TITLE
Apply filters to root element instead of body

### DIFF
--- a/content.js
+++ b/content.js
@@ -141,9 +141,9 @@ function applyFilter(name) {
 		"sepia": "sepia(100%)"
 	};
 	if (name && filters[name]) {
-		document.body.style.filter = filters[name];
+		document.documentElement.style.filter = filters[name];
 	} else {
-		document.body.style.filter = "none";
+		document.documentElement.style.filter = "none";
 	}
 }
 


### PR DESCRIPTION
For whatever reason, applying filters on the root `html` element, instead of `body`, seems to be better supported by websites. Other extensions, such as Dark Reader, take this approach too so it's probably the standard.

Fixes #521.