### PR TITLE
Adjust wildcard tip

### DIFF
--- a/options.html
+++ b/options.html
@@ -56,7 +56,7 @@
 							</p>
 							<p>
 								<strong>Tip:</strong>
-								Use <code>*</code> as <a href="https://www.proginosko.com/leechblock/faq/wildcards/" target="_blank">wildcard</a>,
+								Use <code>*</code> or <code>**</code> as <a href="https://www.proginosko.com/leechblock/faq/wildcards/" target="_blank">wildcard</a>,
 								<code>+</code> to prefix <a href="https://www.proginosko.com/leechblock/faq/exceptions/" target="_blank">exceptions</a>,
 								<code>&gt;</code> to prefix <a href="https://www.proginosko.com/leechblock/faq/referrers/" target="_blank">referrers</a>,
 								and <code>~</code> to prefix <a href="https://www.proginosko.com/leechblock/faq/keywords/" target="_blank">keywords</a>.


### PR DESCRIPTION
As a new user, I tried to make a quick rule to block the reddit homepage and subreddits (unproductive scrolling) but not reddit Google results (useful) and tried to make it happen with just the `*` wildcard, with no luck.

Only after trying for a while I realized there's documentation for wildcards and it mentions the `**` wildcard which breaks through `/` characters:

```
*.reddit.com/*
+*.reddit.com/**comments**
```

I thought it would be nice to modify the tip a bit to make this feature more visible outside the documentation.

This is an opinionated change.