### PR TITLE
Free resources related to tab on tab close

### DIFF
--- a/background.js
+++ b/background.js
@@ -1796,6 +1796,10 @@ function handleTabRemoved(tabId, removeInfo) {
 	if (gTabs[tabId] && gTabs[tabId].url.startsWith(EXTENSION_URL)) {
 		browser.tabs.update(gPrevActiveTabId, { active: true });
 	}
+
+	if (gTabs[tabId]) {
+		delete gTabs[tabId];
+	}
 }
 
 function handleBeforeNavigate(navDetails) {


### PR DESCRIPTION
In initTab, we add an object to the gTabs array when the user creates a new tab, but we never free the resources when the tab is closed.

This change deletes the tab's entry in gTabs when the user closes the tab.

Related #42
Related #124