### PR TITLE
Free page resources on unload event

### DIFF
--- a/content.js
+++ b/content.js
@@ -186,9 +186,22 @@ function onBlur(event) {
 	browser.runtime.sendMessage({ type: "focus", focus: false });
 }
 
+function onUnload(event) {
+  if (gTimer && gTimer.parentNode) {
+    gTimer.parentNode.removeChild(gTimer);
+    gTimer = null;
+  }
+
+  if (gAlert && gAlert.parentNode) {
+    gAlert.parentNode.removeChild(gAlert);
+    gAlert = null;
+  }
+}
+
 browser.runtime.onMessage.addListener(handleMessage);
 
 notifyLoaded();
 
 window.addEventListener("focus", onFocus);
 window.addEventListener("blur", onBlur);
+window.addEventListener("unload", onUnload);


### PR DESCRIPTION
content.js creates timer and alert DOM elements but doesn't free them, which could cause memory leaks. 

This ensures that we delete the elements we created during the page unload event.

Related #42
Related #124