### PR TITLE
Add "Count time on allowed sites" option

### DIFF
--- a/background.js
+++ b/background.js
@@ -573,8 +573,21 @@ function checkTab(id, isBeforeNav, isRepeat) {
 		let prevDebugging = gOptions[`prevDebugging${set}`];
 		let prevOverride = gOptions[`prevOverride${set}`];
 
+		// Get option for counting allowed sites
+		let countAllowed = gOptions[`countAllowed${set}`];
+
 		// Test URL against block/allow regular expressions
-		if (testURL(pageURL, referrer, blockRE, allowRE, referRE, allowRefers)
+		let match = testURL(pageURL, referrer, blockRE, allowRE, referRE, allowRefers);
+		let isAllowedCount = false;
+
+		if (!match && countAllowed && allowRE && allowRE.test(pageURL)) {
+			if (testURL(pageURL, referrer, blockRE, null, referRE, allowRefers)) {
+				match = true;
+				isAllowedCount = true;
+			}
+		}
+
+		if (match
 				|| (prevAddons && /^about:addons/i.test(pageURL))
 				|| (prevSupport && /^about:support/i.test(pageURL))
 				|| (prevProfiles && /^about:profiles/i.test(pageURL))
@@ -669,8 +682,13 @@ function checkTab(id, isBeforeNav, isRepeat) {
 					|| (!conjMode && (withinTimePeriods || afterTimeLimit))
 					|| (conjMode && (withinTimePeriods && afterTimeLimit));
 
+			// Exception page: count time but never block; hide timer when limit reached
+			if (isAllowedCount && doBlock) {
+				showTimer = false;
+			}
+
 			// Apply block if all relevant block conditions are fulfilled
-			if (!override && doBlock && (!isRepeat || activeBlock)) {
+			if (!override && doBlock && (!isRepeat || activeBlock) && !isAllowedCount) {
 
 				function applyBlock(keyword) {
 					if (gDiagMode) {
@@ -935,6 +953,9 @@ function updateTimeData(id, secsOpen, secsFocus) {
 		// Get option for treating referrers as allow-conditions
 		let allowRefers = gOptions[`allowRefers${set}`];
 
+		// Get option for counting allowed sites
+		let countAllowed = gOptions[`countAllowed${set}`];
+
 		// Get URL of page (possibly with hash part)
 		let pageURL = parsedURL.page;
 		if (parsedURL.hash != null) {
@@ -944,7 +965,14 @@ function updateTimeData(id, secsOpen, secsFocus) {
 		}
 
 		// Test URL against block/allow regular expressions
-		if (testURL(pageURL, referrer, blockRE, allowRE, referRE, allowRefers)) {
+		let match = testURL(pageURL, referrer, blockRE, allowRE, referRE, allowRefers);
+		if (!match && countAllowed && allowRE && allowRE.test(pageURL)) {
+			if (testURL(pageURL, referrer, blockRE, null, referRE, allowRefers)) {
+				match = true;
+			}
+		}
+
+		if (match) {
 			// Get options for this set
 			let timedata = gOptions[`timedata${set}`];
 			let countFocus = gOptions[`countFocus${set}`];

--- a/background.js
+++ b/background.js
@@ -573,8 +573,19 @@ function checkTab(id, isBeforeNav, isRepeat) {
 		let prevDebugging = gOptions[`prevDebugging${set}`];
 		let prevOverride = gOptions[`prevOverride${set}`];
 
+		// Get option for counting allowed sites
+		let countAllowed = gOptions[`countAllowed${set}`];
+
 		// Test URL against block/allow regular expressions
-		if (testURL(pageURL, referrer, blockRE, allowRE, referRE, allowRefers)
+		let match = testURL(pageURL, referrer, blockRE, allowRE, referRE, allowRefers);
+
+		// If enabled, also process exception URLs that would otherwise match this set,
+		// so their time counts and the countdown timer shows, but never block them (see below).
+		let isAllowedCount = !match && countAllowed && allowRE && allowRE.test(pageURL)
+				&& testURL(pageURL, referrer, blockRE, null, referRE, allowRefers);
+		if (isAllowedCount) match = true;
+
+		if (match
 				|| (prevAddons && /^about:addons/i.test(pageURL))
 				|| (prevSupport && /^about:support/i.test(pageURL))
 				|| (prevProfiles && /^about:profiles/i.test(pageURL))
@@ -669,8 +680,11 @@ function checkTab(id, isBeforeNav, isRepeat) {
 					|| (!conjMode && (withinTimePeriods || afterTimeLimit))
 					|| (conjMode && (withinTimePeriods && afterTimeLimit));
 
+			// Exception page: once the limit is spent, hide the (now pointless) countdown
+			if (isAllowedCount && doBlock) showTimer = false;
+
 			// Apply block if all relevant block conditions are fulfilled
-			if (!override && doBlock && (!isRepeat || activeBlock)) {
+			if (!override && doBlock && (!isRepeat || activeBlock) && !isAllowedCount) {
 
 				function applyBlock(keyword) {
 					if (gDiagMode) {
@@ -935,6 +949,9 @@ function updateTimeData(id, secsOpen, secsFocus) {
 		// Get option for treating referrers as allow-conditions
 		let allowRefers = gOptions[`allowRefers${set}`];
 
+		// Get option for counting allowed sites
+		let countAllowed = gOptions[`countAllowed${set}`];
+
 		// Get URL of page (possibly with hash part)
 		let pageURL = parsedURL.page;
 		if (parsedURL.hash != null) {
@@ -944,7 +961,12 @@ function updateTimeData(id, secsOpen, secsFocus) {
 		}
 
 		// Test URL against block/allow regular expressions
-		if (testURL(pageURL, referrer, blockRE, allowRE, referRE, allowRefers)) {
+		// If enabled, also count time on exception URLs that would otherwise match this set.
+		let match = testURL(pageURL, referrer, blockRE, allowRE, referRE, allowRefers)
+				|| (countAllowed && allowRE && allowRE.test(pageURL)
+					&& testURL(pageURL, referrer, blockRE, null, referRE, allowRefers));
+
+		if (match) {
 			// Get options for this set
 			let timedata = gOptions[`timedata${set}`];
 			let countFocus = gOptions[`countFocus${set}`];

--- a/common.js
+++ b/common.js
@@ -54,6 +54,7 @@ const PER_SET_OPTIONS = {
 	activeBlock: { type: "boolean", def: false, id: "activeBlock" },
 	minBlock: { type: "string", def: "", id: "minBlock" },
 	countFocus: { type: "boolean", def: true, id: "countFocus" },
+	countAllowed: { type: "boolean", def: false, id: "countAllowed" },
 	countAudio: { type: "boolean", def: false, id: "countAudio" },
 	showKeyword: { type: "boolean", def: true, id: "showKeyword" },
 	titleOnly: { type: "boolean", def: false, id: "titleOnly" },

--- a/options.html
+++ b/options.html
@@ -115,6 +115,10 @@
 								<label for="countFocus1">Count time spent on these sites only when browser tab is active</label>
 							</p>
 							<p class="simplifiable">
+								<input id="countAllowed1" type="checkbox">
+								<label for="countAllowed1">Count time spent on allowed sites (exceptions)</label>
+							</p>
+							<p class="simplifiable">
 								<input id="countAudio1" type="checkbox">
 								<label for="countAudio1">Count time spent on these sites only when browser tab is playing audio</label>
 							</p>


### PR DESCRIPTION
This PR adds an option so that time spent on exception URLs (sites with `+` in the block set) counts toward the set's time limit. Blocking and allowing of sites is unchanged; only what counts toward the limit changes.

**Use case:** The user blocks `[youtube.com](http://youtube.com/)` after 30 min but adds the exception `+[youtube.com/watch](http://youtube.com/watch)` so they can still watch specific YouTube videos. The idea is to allow only videos they deliberately open (e.g. from a Google search or a direct link), not browsing and discovery on YouTube itself. So they get about 30 minutes of YouTube in total, and after that only the main site is blocked; exception URLs like `[youtube.com/watch](http://youtube.com/watch)` stay allowed.

**Current behaviour:** While on YouTube, the 30-minute timer runs. The user can open and watch videos. While they watch videos on `[youtube.com/watch](http://youtube.com/watch)`, the 30-minute timer does **not** run.

**What the new option changes:** When the new setting is enabled, the 30-minute timer **also** runs on exception URLs such as `+[youtube.com/watch](http://youtube.com/watch)`. When the 30 minutes are used up, the main site is blocked; exception pages stay accessible and the timer is hidden on them.

**Changes**
- New option: "Count time spent on allowed sites (exceptions)" in Block Set options (Full Options only).
- When enabled, time on exception URLs counts toward the set's time limit.
- Exception URLs are still never blocked; when the limit is reached they remain open and the countdown is hidden on those pages.

**Testing**
- With the option enabled, time on exception URLs is counted.
- When the limit is reached, the main site is blocked and exception URLs stay open with no timer.
- The option is only visible in Full Options mode.