### PR TITLE
Use visibilitychange event instead of unload event to improve performance and avoid a bug

### DIFF
--- a/content.js
+++ b/content.js
@@ -190,16 +190,18 @@ function onBlur(event) {
 	browser.runtime.sendMessage({ type: "focus", focus: false });
 }
 
-function onUnload(event) {
-	if (gTimer && gTimer.parentNode) {
-		gTimer.parentNode.removeChild(gTimer);
-		gTimer = null;
-	}
+function onVisibilitychange(event) {
+    if (document.hidden) {
+        if (gTimer && gTimer.parentNode) {
+            gTimer.parentNode.removeChild(gTimer);
+            gTimer = null;
+        }
 
-	if (gAlert && gAlert.parentNode) {
-		gAlert.parentNode.removeChild(gAlert);
-		gAlert = null;
-	}
+        if (gAlert && gAlert.parentNode) {
+            gAlert.parentNode.removeChild(gAlert);
+            gAlert = null;
+        }
+    }
 }
 
 browser.runtime.onMessage.addListener(handleMessage);
@@ -208,4 +210,4 @@ notifyLoaded();
 
 window.addEventListener("focus", onFocus);
 window.addEventListener("blur", onBlur);
-window.addEventListener("unload", onUnload);
+window.addEventListener("visibilitychange", onVisibilitychange);

--- a/content.js
+++ b/content.js
@@ -190,17 +190,15 @@ function onBlur(event) {
 	browser.runtime.sendMessage({ type: "focus", focus: false });
 }
 
-function onVisibilitychange(event) {
-    if (document.hidden) {
-        if (gTimer && gTimer.parentNode) {
-            gTimer.parentNode.removeChild(gTimer);
-            gTimer = null;
-        }
+function onPagehide(event) {
+    if (gTimer && gTimer.parentNode) {
+        gTimer.parentNode.removeChild(gTimer);
+        gTimer = null;
+    }
 
-        if (gAlert && gAlert.parentNode) {
-            gAlert.parentNode.removeChild(gAlert);
-            gAlert = null;
-        }
+    if (gAlert && gAlert.parentNode) {
+        gAlert.parentNode.removeChild(gAlert);
+        gAlert = null;
     }
 }
 
@@ -210,4 +208,4 @@ notifyLoaded();
 
 window.addEventListener("focus", onFocus);
 window.addEventListener("blur", onBlur);
-window.addEventListener("visibilitychange", onVisibilitychange);
+window.addEventListener("pagehide", onPagehide);


### PR DESCRIPTION
The "unload" event has these drawbacks:

- It breaks the browser's back/forward cache (bfcache), worsening the performance of the browser when pressing the back button or forward button
- It may be disabled entirely be the website's `Permissions-Policy`

It is preferable to use the "visibilitychange" or "pagehide" events instead. These events have been supported across browsers since April 2021 and July 2015, respectively. `document.hidden` has been supported across browsers since July 2015. This pull request makes the required change.

See:

https://web.dev/articles/bfcache#optimize

https://developer.mozilla.org/en-US/docs/Glossary/bfcache