### PR TITLE
Load options from managed storage if available

### DIFF
--- a/background.js
+++ b/background.js
@@ -1645,6 +1645,24 @@ function addSitesToSet(siteList, set) {
 
 /*** EVENT HANDLERS BEGIN HERE ***/
 
+function fetchFromManagedStorage() {
+	let data = browser.storage.managed.get().catch((exc) => {
+		return Promise.reject(exc);
+	});
+	data.then(onGot, (error) => {
+		log("Could not get options from managed storage: " + error);
+	});
+
+	function onGot(data) {
+		browser.storage.local.set(data).then(
+			() => log("Copied settings from managed to local storage"),
+			(error) => {
+				log("Could not copy options from managed to local storage: " + error);
+			},
+		);
+	}
+}
+
 function handleMenuClick(info, tab) {
 	let id = info.menuItemId;
 	if (id == "options") {
@@ -1941,6 +1959,7 @@ function onAlarm(alarmInfo) {
 
 /*** STARTUP CODE BEGINS HERE ***/
 
+browser.runtime.onStartup.addListener(fetchFromManagedStorage);
 browser.runtime.getPlatformInfo().then(
 	function (info) { gIsAndroid = (info.os == "android"); }
 );


### PR DESCRIPTION
Following the discussion in #368, I have made it so LeechBlockNG copies options from managed to local storage on browser startup (when Firefox reads managed storage).

If there is no managed storage set, this is simply logged and everything works with local storage as usual. If managed storage for this extension is available, the local storage options will be overridden with the managed ones. It is then up to the user to make sure options cannot be changed via the options menu, for example by setting a password.

I have tested this on Linux, with Firefox developer edition 154.0b1. It should work the same on Windows and MacOS, as long as the user follows Mozilla's instructions on how to set managed storage. The code will probably even work in Chromium based browsers, though I have not tested these.

The following configurations for managed storage work, using the json data generated by the export option:
- No policy or managed storage file (nothing happens)
- Policy in `/etc/firefox/policies/policies.json`, with 3rdparty key (see [Firefox docs](https://firefox-admin-docs.mozilla.org/reference/policies/3rdparty/))
- Policy in `firefox/distribution/policies.json`
- Managed storage file in `/usr/lib/mozilla/managed-storage/leechblockng@proginosko.com.json` (see [Firefox docs](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_manifests#managed_storage_manifests))
- Managed storage file in `~/.mozilla/managed-storage/leechblockng@proginosko.com.json`

Thanks so much for making and maintaining this extension!